### PR TITLE
Handle when a unit prefix is absent

### DIFF
--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -143,7 +143,7 @@ class Normalizer
 
         $this->zip_regexp = '(\d{5})(?:-?(\d{4})?)';
         $this->corner_regexp = '(?:\band\b|\bat\b|&|\@)';
-        $this->unit_regexp = '(?:(su?i?te|p\W*[om]\W*b(?:ox)?|dept|apt|apartment|ro*m|fl|unit|box)\W+|\#\W*)([\w-]+)';
+        $this->unit_regexp = '(?:(su?i?te|p\W*[om]\W*b(?:ox)?|dept|apt|apartment|ro*m|fl|unit|box)\W+|\#\W*|)([\w-]+)';
         $this->street_regexp =
             '(?:'
             . '(?:(' . $this->direct_regexp . ')\W+'

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -97,4 +97,48 @@ class NormalizerTest extends TestCase
 
         $this->assertFalse($normalizer->parse($badAddress));
     }
+
+    /** @test */
+    public function testHandlesAddressWithoutUnitPrefix()
+    {
+        $normalizer = new Normalizer();
+
+        $addresses = [
+            [ // Test without unit prefix
+                'test' => '1234 W Main Avenue 1W, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main Ave #1W, Chicago, IL 60647'
+            ],
+            [ // Regression test with unit prefix
+                'test' => '1234 W Main Avenue Unit 1W, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main Ave Unit 1W, Chicago, IL 60647'
+            ],
+            [ // Regression test with unit prefix
+                'test' => '1234 W Main Avenue Apartment 1W, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main Ave Apartment 1W, Chicago, IL 60647'
+            ],
+            [ // Regression test with unit prefix
+                'test' => '1234 W Main Avenue #1W, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main Ave #1W, Chicago, IL 60647'
+            ],
+            [ // Regression test with unit prefix
+                'test' => '1234 W Main Avenue Room 1, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main Ave Room 1, Chicago, IL 60647'
+            ],
+            [ // Regression test with unit prefix
+                'test' => '1234 W Main Avenue Apt 1W, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main Ave Apt 1W, Chicago, IL 60647'
+            ],
+            [ // Regression test without any unit
+                'test' => '1234 W Main Street, Chicago, IL, 60647',
+                'expected_result' => '1234 W Main St, Chicago, IL 60647'
+            ],
+        ];
+
+        foreach ($addresses as $address) {
+            $this->assertEquals(
+                $address['expected_result'],
+                (string)$normalizer->parse($address['test'])
+            );
+        }
+    }
 }


### PR DESCRIPTION
Update to the regex that parses the unit information from an address to handle when a unit might not have a prefix. 
Old behavior: Regex would not parse out the street name correctly if a unit prefix was not used ("1234 W Main St 1W, Chicago IL" would result in "1234 W, Chicago IL")
New behavior: Regex parses out address correctly even without a unit prefix ("1234 W Main St 1W, Chicago IL" now results in "1234 W Main St #1W, Chicago IL")